### PR TITLE
feat: Implement yt-dlp Web UI with download options and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# yt-dlp Web UI
+
+## Description
+
+This project provides a web-based user interface for the powerful `yt-dlp` command-line video downloader. Its purpose is to offer a more user-friendly way to interact with some of `yt-dlp`'s most common features without needing to use the command line directly.
+
+## Features
+
+-   **Video Information**: Fetches and displays available video formats, thumbnail, title, uploader, duration, and description.
+-   **Video and Audio Downloads**: Supports downloading video and audio content.
+-   **User-Configurable Download Options**:
+    -   **Audio-Only**: Option to download only the audio track.
+    -   **Audio Format Selection**: Choose preferred audio format (MP3, M4A, Opus, WAV, or Best).
+    -   **Video Quality Selection**: Choose preferred video quality (Best, 1080p, 720p, 480p, or 360p) for video downloads.
+    -   **Subtitle Embedding**: Option to embed English subtitles into the video (if available).
+-   **Responsive Design**: The UI is designed to be usable on various screen sizes.
+
+## Core Technology
+
+This web UI is a wrapper around the versatile `yt-dlp` tool. All video fetching and downloading capabilities are powered by `yt-dlp`.
+
+-   **`yt-dlp` Official Repository**: [https://github.com/yt-dlp/yt-dlp](https://github.com/yt-dlp/yt-dlp)
+
+## Setup and Installation
+
+### Prerequisites
+
+-   **Python 3.x**: Ensure Python 3 (version 3.7 or newer recommended) is installed.
+-   **`pip`**: The Python package installer, usually included with Python.
+-   **`ffmpeg`**: `yt-dlp` requires `ffmpeg` for many operations, especially for merging separate video and audio streams (common for high-quality formats) or for converting audio formats.
+    -   Download `ffmpeg` from [ffmpeg.org](https://ffmpeg.org/download.html) or use pre-built static versions from [yt-dlp/FFmpeg-Builds](https://github.com/yt-dlp/FFmpeg-Builds). Ensure `ffmpeg` (and `ffprobe`) is in your system's PATH or accessible by `yt-dlp`.
+
+### Installation Steps
+
+1.  **Clone the repository** (or download and extract the source code):
+    ```bash
+    # Replace <repository_url> with the actual URL of this project
+    git clone <repository_url>
+    cd <repository_directory_name> 
+    ```
+
+2.  **Create and activate a virtual environment** (highly recommended):
+    ```bash
+    python -m venv venv
+    ```
+    -   On macOS and Linux:
+        ```bash
+        source venv/bin/activate
+        ```
+    -   On Windows:
+        ```bash
+        venv\Scripts\activate
+        ```
+
+3.  **Install dependencies**:
+    ```bash
+    pip install Flask yt-dlp
+    ```
+
+## Running the Application
+
+1.  **Start the Flask server**:
+    ```bash
+    python web_server.py
+    ```
+
+2.  **Access the Web UI**:
+    Open your web browser and go to: `http://127.0.0.1:5000`
+
+    **Note on Downloads**: When you download a file, it is first downloaded to a temporary `downloads` directory on the server. The file is then streamed to your browser. After the stream is complete (or if an error occurs), the file is automatically deleted from the server's `downloads` directory.
+
+## How to Use
+
+1.  Open the web application in your browser.
+2.  Enter the URL of the video you want to download into the input field.
+3.  Adjust the "Download Options" (audio only, audio format, video quality, embed subtitles) as needed.
+4.  Click the "Fetch Formats" button.
+5.  The application will display video metadata and a list of available formats.
+6.  Find your desired format in the list and click the "Download (Direct)" or "Download (via Server)" button next to it.
+    - "Download (Direct)" links attempt to use the direct URL from the content provider if no server-side processing (like audio extraction or subtitle embedding) is needed.
+    - "Download (via Server)" will process the download through the backend, applying any selected options.
+
+## Disclaimer
+
+This project relies entirely on `yt-dlp` for its functionality. Please ensure that your use of this tool complies with the terms of service of any websites you are downloading content from. Respect copyright laws and the rights of content creators. This tool is provided for personal, fair use only.

--- a/index.html
+++ b/index.html
@@ -7,16 +7,61 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="container">
+    <main class="container">
         <h1>yt-dlp Web UI</h1>
-        <div class="input-section">
-            <input type="text" id="videoUrl" placeholder="Enter video URL">
-            <button id="fetchButton">Fetch Formats</button>
+        <form class="input-section" onsubmit="return false;"> <!-- Prevent default form submission -->
+            <label for="videoUrl" class="sr-only">Video URL</label> <!-- Screen-reader only label -->
+            <input type="text" id="videoUrl" placeholder="Enter video URL" aria-label="Video URL">
+            <button type="button" id="fetchButton">Fetch Formats</button> <!-- type="button" to prevent form submission -->
+        </form>
+
+        <fieldset class="options-section">
+            <legend><h3>Download Options:</h3></legend>
+            <div>
+                <input type="checkbox" id="audioOnly" name="audioOnly">
+                <label for="audioOnly">Download audio only</label>
+            </div>
+            <div id="audioFormatContainer" style="display: none; margin-top: 5px; margin-left: 20px;">
+                <label for="audioFormat">Audio Format:</label>
+                <select id="audioFormat" name="audioFormat">
+                    <option value="best">Best</option>
+                    <option value="mp3">MP3</option>
+                    <option value="m4a">M4A</option>
+                    <option value="opus">Opus</option>
+                    <option value="wav">WAV</option>
+                </select>
+            </div>
+            <div style="margin-top: 10px;">
+                <label for="videoQuality">Video Quality:</label>
+                <select id="videoQuality" name="videoQuality">
+                    <option value="best">Best</option>
+                    <option value="1080">1080p</option>
+                    <option value="720">720p</option>
+                    <option value="480">480p</option>
+                    <option value="360">360p</option>
+                </select>
+            </div>
+            <div style="margin-top: 10px;">
+                <input type="checkbox" id="embedSubs" name="embedSubs">
+                <label for="embedSubs">Embed subtitles (if available, English)</label>
+            </div>
         </div>
-        <div id="videoInfo" class="video-info-section">
-            <!-- Video formats will be displayed here -->
-        </div>
-    </div>
+
+        <div id="loadingIndicator" style="display: none; text-align: center; padding: 20px;">Loading...</div>
+        <article id="videoInfo" class="video-info-section" style="display: none;" aria-live="polite">
+            <h2 id="videoTitle"></h2>
+            <img id="videoThumbnail" src="" alt="Video thumbnail" style="display: none; max-width: 100%; height: auto; margin: 10px auto; border-radius: 4px;">
+            <p><strong>Uploader:</strong> <span id="videoUploader"></span></p>
+            <p><strong>Duration:</strong> <span id="videoDuration"></span></p>
+            <p><strong>Description:</strong></p>
+            <div id="videoDescription" class="video-description"></div>
+            <h3>Available Formats:</h3>
+            <ul id="formatsList" aria-label="List of available video formats">
+                <!-- Video formats will be displayed here -->
+            </ul>
+        </article>
+        <div id="downloadFeedback" style="display: none;" role="status" aria-live="polite"></div>
+    </main>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,16 +1,81 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const videoUrlInput = document.getElementById('videoUrl');
-    const fetchButton = document.getElementById('fetchButton');
-    const videoInfoDiv = document.getElementById('videoInfo');
+    // DOM Element References
+    const elements = {
+        videoUrlInput: document.getElementById('videoUrl'),
+        fetchButton: document.getElementById('fetchButton'),
+        loadingIndicator: document.getElementById('loadingIndicator'),
+        videoInfoDiv: document.getElementById('videoInfo'),
+        videoTitleEl: document.getElementById('videoTitle'),
+        videoThumbnailEl: document.getElementById('videoThumbnail'),
+        videoUploaderEl: document.getElementById('videoUploader'),
+        videoDurationEl: document.getElementById('videoDuration'),
+        videoDescriptionEl: document.getElementById('videoDescription'),
+        formatsListEl: document.getElementById('formatsList'),
+        downloadFeedbackEl: document.getElementById('downloadFeedback'),
+        // Download Options Elements
+        audioOnlyCheckbox: document.getElementById('audioOnly'),
+        audioFormatContainer: document.getElementById('audioFormatContainer'),
+        audioFormatSelect: document.getElementById('audioFormat'),
+        videoQualitySelect: document.getElementById('videoQuality'),
+        embedSubsCheckbox: document.getElementById('embedSubs'),
+    };
 
-    fetchButton.addEventListener('click', async () => {
-        const url = videoUrlInput.value.trim();
+    // Event listener for audioOnly checkbox
+    elements.audioOnlyCheckbox.addEventListener('change', () => {
+        elements.audioFormatContainer.style.display = elements.audioOnlyCheckbox.checked ? 'block' : 'none';
+        elements.videoQualitySelect.disabled = elements.audioOnlyCheckbox.checked;
+        // if (elements.audioOnlyCheckbox.checked) {
+            // Optionally reset video quality if audio only is selected
+            // elements.videoQualitySelect.value = 'best'; 
+        // }
+    });
+
+    // Function to display error messages
+    function displayError(message) {
+        elements.loadingIndicator.style.display = 'none';
+        elements.videoInfoDiv.style.display = 'block'; // Show the info section to display the error
+        
+        // Clear previous content
+        elements.videoTitleEl.textContent = 'Error';
+        elements.videoThumbnailEl.src = '';
+        elements.videoThumbnailEl.style.display = 'none';
+        elements.videoUploaderEl.textContent = '';
+        elements.videoDurationEl.textContent = '';
+        elements.formatsListEl.innerHTML = ''; // Clear formats list
+        
+        // Display error message in description area, styled
+        elements.videoDescriptionEl.innerHTML = `<p class="error-message">${message}</p>`;
+    }
+
+    elements.fetchButton.addEventListener('click', async () => {
+        const url = elements.videoUrlInput.value.trim();
+        
+        // Basic client-side URL validation
         if (!url) {
-            alert('Please enter a video URL.');
+            displayError('Please enter a video URL.'); 
+            return;
+        }
+        if (!url.toLowerCase().startsWith('http') && !url.toLowerCase().startsWith('www.')) {
+            displayError('Please enter a valid URL (e.g., starting with http://, https://, or www.).');
             return;
         }
 
-        videoInfoDiv.innerHTML = '<p>Fetching video information...</p>';
+        // Collect download options
+        const options = {
+            audioOnly: elements.audioOnlyCheckbox.checked,
+            audioFormat: elements.audioFormatSelect.value,
+            videoQuality: elements.videoQualitySelect.value,
+            embedSubs: elements.embedSubsCheckbox.checked,
+        };
+
+        // Reset UI for new request
+        elements.loadingIndicator.style.display = 'block';
+        elements.videoInfoDiv.style.display = 'none'; 
+        elements.formatsListEl.innerHTML = ''; 
+        elements.downloadFeedbackEl.style.display = 'none';
+        elements.videoThumbnailEl.src = ''; // Clear previous thumbnail
+        elements.videoThumbnailEl.style.display = 'none';
+        elements.videoDescriptionEl.innerHTML = ''; // Clear previous description/error
 
         try {
             const response = await fetch('/get_video_info', {
@@ -18,61 +83,155 @@ document.addEventListener('DOMContentLoaded', () => {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ url: url }),
+                body: JSON.stringify({ url: url, options: options }), 
             });
 
+            elements.loadingIndicator.style.display = 'none'; // Hide loading indicator once response is received
+
             if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+                let errorMsg = `HTTP error! status: ${response.status}`;
+                try {
+                    const errorData = await response.json();
+                    errorMsg = errorData.error || errorMsg;
+                } catch (e) {
+                    // Could not parse JSON error, stick with HTTP status
+                }
+                throw new Error(errorMsg);
             }
 
             const data = await response.json();
 
             if (data.error) {
-                videoInfoDiv.innerHTML = `<p style="color: red;">Error: ${data.error}</p>`;
-            } else if (data.formats && data.formats.length > 0) {
-                displayFormats(data.formats, url, data.title || 'Video');
+                displayError(data.error);
             } else {
-                videoInfoDiv.innerHTML = '<p>No downloadable formats found or error in processing.</p>';
+                elements.videoInfoDiv.style.display = 'block'; // Show info section for results
+                displayVideoMetadata(data); // data contains title, uploader etc.
+                
+                if (data.formats && Array.isArray(data.formats) && data.formats.length > 0) {
+                    const currentOptions = { // These are the options active at the moment of fetching
+                        audioOnly: elements.audioOnlyCheckbox.checked,
+                        audioFormat: elements.audioFormatSelect.value,
+                        videoQuality: elements.videoQualitySelect.value,
+                        embedSubs: elements.embedSubsCheckbox.checked,
+                    };
+                    displayFormats(data.formats, url, currentOptions); // Pass formats array and original URL
+                } else {
+                    // No specific formats found, but we might have other video info.
+                    elements.formatsListEl.innerHTML = '<li>No downloadable formats found. The URL might be for an unsupported site, a non-video page, or the video has no separate formats.</li>';
+                }
             }
 
         } catch (error) {
             console.error('Fetch error:', error);
-            videoInfoDiv.innerHTML = `<p style="color: red;">Failed to fetch video information: ${error.message}</p>`;
+            displayError(`Failed to fetch video information: ${error.message}`);
         }
     });
 
-    function displayFormats(formats, originalUrl, videoTitle) {
-        videoInfoDiv.innerHTML = `<h2>${videoTitle}</h2>`;
-        const list = document.createElement('ul');
-        list.style.listStyleType = 'none';
-        list.style.padding = '0';
+    function displayVideoMetadata(data) {
+        elements.videoTitleEl.textContent = data.title || 'Video Title Not Available';
+        
+        if (data.thumbnail) {
+            elements.videoThumbnailEl.src = data.thumbnail;
+            elements.videoThumbnailEl.style.display = 'block';
+        } else {
+            elements.videoThumbnailEl.style.display = 'none'; // Ensure it's hidden if no thumbnail
+        }
+        
+        elements.videoUploaderEl.textContent = data.uploader || 'N/A';
+        elements.videoDurationEl.textContent = data.duration_string || 'N/A';
+        // Clear previous error styling if any, then set description
+        elements.videoDescriptionEl.className = 'video-description'; // Reset class
+        elements.videoDescriptionEl.textContent = data.description || 'No description available.';
+    }
+
+    // Function to display available formats
+    function displayFormats(formats, originalUrl, downloadOptions) { 
+        elements.formatsListEl.innerHTML = ''; // Clear previous list
 
         formats.forEach(format => {
             const listItem = document.createElement('li');
             listItem.className = 'format-item';
 
-            let formatDescription = `${format.ext} - ${format.format_note || format.resolution || format.format_id}`;
+            // Defensive access to format properties
+            const formatId = format.format_id || 'N/A';
+            const ext = format.ext || 'N/A';
+            const resolution = format.resolution || 'N/A';
+            const formatNote = format.format_note || ''; // Specific notes about the format
+            const vcodec = format.vcodec || 'N/A';
+            const acodec = format.acodec || 'N/A';
+            const fps = format.fps || ''; // Frames per second
+            const lang = format.language || ''; // Language of the stream
+            const proto = format.protocol || ''; // Protocol (e.g., https, m3u8)
+
+            // Construct details string
+            let formatDetails = `<strong>Format: ${formatId} (${ext})</strong>`;
+            formatDetails += ` | Resolution: ${resolution}`;
+            if (formatNote) formatDetails += ` (${formatNote})`;
+            
+            formatDetails += `<br>Codecs: Video - ${vcodec}, Audio - ${acodec}`;
+            if (fps) formatDetails += ` | FPS: ${fps}`;
+            
+            let bitrates = [];
+            if (format.vbr) bitrates.push(`Video: ${Number(format.vbr).toFixed(2)} kbps`);
+            if (format.abr) bitrates.push(`Audio: ${Number(format.abr).toFixed(2)} kbps`);
+            if (bitrates.length > 0) formatDetails += ` | Bitrates: ${bitrates.join(', ')}`;
+
+            let fileSize = '';
             if (format.filesize) {
-                formatDescription += ` (${(format.filesize / 1024 / 1024).toFixed(2)} MB)`;
+                fileSize = `(${(Number(format.filesize) / 1024 / 1024).toFixed(2)} MB)`;
             } else if (format.filesize_approx) {
-                formatDescription += ` (~${(format.filesize_approx / 1024 / 1024).toFixed(2)} MB)`;
+                fileSize = `(~${(Number(format.filesize_approx) / 1024 / 1024).toFixed(2)} MB)`;
             }
+            if (fileSize) formatDetails += ` | Size: ${fileSize}`;
+
+            if (lang) formatDetails += ` | Language: ${lang}`;
+            if (proto) formatDetails += ` | Protocol: ${proto}`;
 
 
-            const descriptionSpan = document.createElement('span');
-            descriptionSpan.textContent = formatDescription;
+            const detailsDiv = document.createElement('div');
+            detailsDiv.className = 'format-details';
+            detailsDiv.innerHTML = formatDetails;
 
             const downloadButton = document.createElement('a');
-            downloadButton.href = `/download_video?url=${encodeURIComponent(originalUrl)}&format_id=${encodeURIComponent(format.format_id)}`;
-            downloadButton.textContent = 'Download';
+            // Use format.url if available and protocol is http/https, otherwise use backend downloader
+            let downloadUrl = '';
+            // Check format.url, format.protocol, downloadOptions.audioOnly, downloadOptions.embedSubs
+            if (format.url && 
+                (proto === 'http' || proto === 'https') && // Use safe 'proto'
+                !downloadOptions.audioOnly && 
+                !downloadOptions.embedSubs) {
+                 downloadButton.href = format.url; 
+                 downloadButton.textContent = 'Download (Direct)';
+            } else {
+                // Construct URL with options for server-side download
+                downloadUrl = `/download_video?url=${encodeURIComponent(originalUrl)}&format_id=${encodeURIComponent(formatId)}`;
+                downloadUrl += `&audioOnly=${downloadOptions.audioOnly}`;
+                if (downloadOptions.audioOnly) { 
+                    downloadUrl += `&audioFormat=${encodeURIComponent(downloadOptions.audioFormat)}`;
+                }
+                if (!downloadOptions.audioOnly) {
+                    downloadUrl += `&videoQuality=${encodeURIComponent(downloadOptions.videoQuality)}`;
+                }
+                downloadUrl += `&embedSubs=${downloadOptions.embedSubs}`;
+                
+                downloadButton.href = downloadUrl;
+                downloadButton.textContent = 'Download (via Server)';
+            }
             downloadButton.className = 'download-button';
-            downloadButton.target = '_blank'; // Open download in a new tab
+            downloadButton.target = '_blank'; // Open in new tab to not interrupt current page
 
-            listItem.appendChild(descriptionSpan);
+            downloadButton.addEventListener('click', () => {
+                elements.downloadFeedbackEl.textContent = `Download initiated for format ${formatId || ext}...`; // Use safe formatId or ext
+                elements.downloadFeedbackEl.style.display = 'block';
+                // Hide feedback after a few seconds
+                setTimeout(() => {
+                    elements.downloadFeedbackEl.style.display = 'none';
+                }, 5000);
+            });
+
+            listItem.appendChild(detailsDiv);
             listItem.appendChild(downloadButton);
-            list.appendChild(listItem);
+            elements.formatsListEl.appendChild(listItem);
         });
-        videoInfoDiv.appendChild(list);
     }
 });

--- a/style.css
+++ b/style.css
@@ -28,7 +28,7 @@ h1 {
 .input-section {
     display: flex;
     gap: 10px;
-    margin-bottom: 30px;
+    margin-bottom: 20px; /* Adjusted margin */
 }
 
 #videoUrl {
@@ -37,7 +37,7 @@ h1 {
     border: 1px solid #ccc;
     border-radius: 4px;
     font-size: 16px;
-    box-sizing: border-box; /* Ensures padding doesn't affect width */
+    box-sizing: border-box;
 }
 
 #fetchButton {
@@ -55,51 +55,207 @@ h1 {
     background-color: #2980b9;
 }
 
-.video-info-section {
-    margin-top: 20px;
+/* Screen-reader only utility class */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
 }
 
-.video-info-section h2 {
+
+/* === Options Section === */
+.options-section {
+    background-color: #f9f9f9;
+    padding: 15px 20px 5px 20px; /* Adjusted padding */
+    border-radius: 6px;
+    margin-bottom: 25px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    border: 1px solid #e0e0e0; /* Subtle border */
+}
+
+.options-section legend { /* Style the legend directly */
+    font-size: 1.2em; /* Corresponds to h3 a bit */
+    font-weight: bold;
     color: #34495e;
-    margin-bottom: 15px;
+    padding: 0 5px; /* Give some spacing around the legend text */
+    margin-bottom: 10px; /* Space below legend */
 }
 
-.format-item {
-    background-color: #ecf0f1;
-    padding: 15px;
-    margin-bottom: 10px;
+.options-section div { /* Applies to checkbox/label containers */
+    margin-bottom: 15px; /* Increased spacing between option rows */
+}
+
+.options-section label {
+    margin-left: 5px;
+    color: #333;
+    font-size: 0.95em;
+}
+
+.options-section input[type="checkbox"] {
+    margin-right: 5px;
+    vertical-align: middle;
+}
+
+.options-section select {
+    padding: 8px 10px;
     border-radius: 4px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    border: 1px solid #ccc;
+    font-size: 0.9em;
+    min-width: 150px; /* Give select some base width */
 }
 
-.format-item span {
-    font-size: 14px;
+#audioFormatContainer label, 
+#videoQuality label { /* Labels for select dropdowns */
+    margin-right: 8px;
+    font-weight: 500; /* Make them slightly bolder */
+}
+
+
+/* === Loading, Feedback, and Error Messages === */
+#loadingIndicator {
+    text-align: center;
+    padding: 20px;
+    font-size: 1.1em; /* Slightly larger */
     color: #555;
 }
 
+#downloadFeedback {
+    text-align: center;
+    padding: 12px; /* Adjusted padding */
+    margin-top: 20px; /* Increased margin */
+    background-color: #e6fffa;
+    color: #007a5e;
+    border: 1px solid #b2f0e1;
+    border-radius: 4px;
+    font-size: 1em;
+}
+
+.error-message {
+    color: #b94a48; /* Darker red for better contrast */
+    background-color: #f2dede;
+    border: 1px solid #ebccd1;
+    padding: 15px;
+    border-radius: 4px;
+    margin-top: 10px; /* Ensure it has some space if it's the only content in videoDescriptionEl */
+    text-align: left; 
+}
+
+
+/* === Video Information Section === */
+.video-info-section { /* This is <article id="videoInfo"> */
+    margin-top: 20px;
+    padding: 20px;
+    background-color: #f9f9f9;
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    border: 1px solid #e0e0e0; /* Consistent border */
+}
+
+#videoTitle { /* This is <h2 id="videoTitle"> */
+    color: #34495e;
+    margin-top: 0; /* Remove top margin if it's the first child */
+    margin-bottom: 15px;
+    text-align: center;
+    font-size: 1.5em; /* Ensure it's prominent */
+}
+
+#videoThumbnail {
+    display: block; 
+    max-width: 100%;
+    height: auto;
+    margin: 15px auto 20px auto; /* Adjusted margins */
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.video-info-section p { /* Paragraphs holding Uploader, Duration */
+    margin-bottom: 10px; /* Slightly more spacing */
+    line-height: 1.6;
+}
+
+.video-description { /* This is <div id="videoDescription"> */
+    margin-top: 10px; /* Space from "Description:" paragraph */
+    padding: 10px;
+    background-color: #e9ecef;
+    border-radius: 4px;
+    max-height: 150px; 
+    overflow-y: auto; 
+    margin-bottom: 20px;
+    line-height: 1.5;
+    font-size: 0.95em;
+    color: #495057;
+}
+
+.video-info-section h3 { /* "Available Formats:" heading */
+    margin-top: 25px;
+    margin-bottom: 15px;
+    color: #34495e;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 8px; /* Increased padding */
+    font-size: 1.3em; /* Make it a bit larger */
+}
+
+
+/* === Formats List === */
+#formatsList {
+    list-style-type: none;
+    padding: 0;
+}
+
+.format-item { /* Each <li> for a format */
+    background-color: #ecf0f1;
+    padding: 15px;
+    margin-bottom: 12px; /* Slightly increased margin */
+    border-radius: 5px; /* Slightly more rounded */
+    display: flex;
+    flex-direction: column; /* Stack details and button vertically */
+    gap: 10px; /* Space between details and button */
+    box-shadow: 0 2px 5px rgba(0,0,0,0.07);
+    transition: box-shadow 0.2s ease-in-out;
+}
+
+.format-item:hover {
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.format-details { /* Class for the div containing format information */
+    font-size: 0.9em; /* Slightly smaller font for details */
+    color: #333;
+    line-height: 1.5;
+}
+
+.format-details strong {
+    color: #2c3e50;
+}
+
 .format-item .download-button {
-    padding: 8px 15px;
+    padding: 10px 15px; /* Adjusted padding */
     background-color: #2ecc71;
     color: white;
     border: none;
     border-radius: 4px;
     cursor: pointer;
-    font-size: 14px;
-    text-decoration: none; /* Remove underline from links styled as buttons */
+    font-size: 15px; /* Adjusted font size */
+    text-decoration: none;
     transition: background-color 0.3s ease;
+    align-self: flex-start; 
 }
 
 .format-item .download-button:hover {
     background-color: #27ae60;
 }
 
-/* Responsive adjustments */
+
+/* === Responsive Adjustments === */
 @media (max-width: 600px) {
     .container {
-        margin: 20px;
+        margin: 15px; /* Slightly reduce margin for very small screens */
         padding: 20px;
     }
 

--- a/web_server.py
+++ b/web_server.py
@@ -1,9 +1,18 @@
-import json
 import os
-from flask import Flask, request, jsonify, send_from_directory, Response
+import json # Used by app.logger.debug for pretty printing opts
+from flask import Flask, request, jsonify, send_from_directory
 from yt_dlp import YoutubeDL
 
-app = Flask(__name__, static_folder='web')
+app = Flask(__name__, static_folder='web') # 'web' is not used as static_folder, files are at root.
+                                         # However, this doesn't break anything for the current setup.
+                                         # For correctness if actual static files were in /web, it would be:
+                                         # app = Flask(__name__, static_folder='static')
+                                         # and ensure an actual 'static' folder exists.
+                                         # Given current structure, static_folder isn't strictly necessary
+                                         # as Flask serves index.html from root by default if no static_folder is hit.
+                                         # For clarity, could be app = Flask(__name__) if no distinct static folder.
+                                         # Let's assume the intent was to serve from root, so Flask's default is fine.
+app = Flask(__name__) # Simplified as static files are served from root.
 
 # Ensure the 'downloads' directory exists
 DOWNLOADS_DIR = os.path.join(os.getcwd(), 'downloads')
@@ -12,130 +21,265 @@ if not os.path.exists(DOWNLOADS_DIR):
 
 @app.route('/')
 def index():
-    return send_from_directory(app.static_folder, 'index.html')
+    # Serves index.html from the root directory where web_server.py is located
+    return send_from_directory(os.getcwd(), 'index.html')
 
-@app.route('/<path:path>')
-def send_static(path):
-    return send_from_directory(app.static_folder, path)
+@app.route('/<path:filename>')
+def send_static_file(filename):
+    # Serves other static files like script.js, style.css from the root directory
+    return send_from_directory(os.getcwd(), filename)
 
 @app.route('/get_video_info', methods=['POST'])
 def get_video_info():
     data = request.get_json()
     url = data.get('url')
+    # Options from client (e.g., audioOnly) are received but not used by this endpoint,
+    # as its primary goal is to list all available formats.
+    # client_options = data.get('options', {}) 
+
     if not url:
+        app.logger.warning("URL is required but not provided.")
         return jsonify({'error': 'URL is required'}), 400
 
+    app.logger.info(f"Fetching video info for URL: {url}")
     try:
+        # ydl_opts for fetching information without downloading
         ydl_opts = {
-            'noplaylist': True,
+            'noplaylist': True, # Ensure we don't process playlists
             'quiet': True,
             'no_warnings': True,
             # 'skip_download': True, # We are only fetching info
-            'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best', # Example, might want more flexibility
+            # 'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best', # Removed for comprehensive format listing
         }
         with YoutubeDL(ydl_opts) as ydl:
             info = ydl.extract_info(url, download=False)
             formats = []
             if 'formats' in info:
                 for f in info['formats']:
-                    # Include only formats that are likely downloadable and have essential info
-                    if f.get('url') or f.get('manifest_url'): # Check if there's a direct URL or manifest
-                         formats.append({
-                            'format_id': f.get('format_id'),
-                            'ext': f.get('ext'),
-                            'resolution': f.get('resolution') or f.get('format_note'),
-                            'format_note': f.get('format_note'),
-                            'filesize': f.get('filesize'),
-                            'filesize_approx': f.get('filesize_approx'),
-                            'fps': f.get('fps'),
-                            'vcodec': f.get('vcodec'),
-                            'acodec': f.get('acodec'),
-                        })
-            # Fallback if no formats are explicitly listed but there's a direct URL (e.g. for single-file downloads)
-            elif 'url' in info:
-                 formats.append({
-                    'format_id': info.get('format_id', 'best'),
+                    # Be more inclusive with formats
+                    formats.append({
+                        'format_id': f.get('format_id'),
+                        'ext': f.get('ext'),
+                        'resolution': f"{f.get('width')}x{f.get('height')}" if f.get('width') and f.get('height') else f.get('resolution'),
+                        'format_note': f.get('format_note'),
+                        'filesize': f.get('filesize'),
+                        'filesize_approx': f.get('filesize_approx'),
+                        'fps': f.get('fps'),
+                        'vcodec': f.get('vcodec'),
+                        'acodec': f.get('acodec'),
+                        'tbr': f.get('tbr'),
+                        'abr': f.get('abr'),
+                        'vbr': f.get('vbr'),
+                        'url': f.get('url'),
+                        'manifest_url': f.get('manifest_url'),
+                        'protocol': f.get('protocol'),
+                        'language': f.get('language'),
+                    })
+            # Fallback if no 'formats' array, but top-level URL exists (e.g., direct image URL)
+            elif 'url' in info: # This case might be rare for typical video URLs yt-dlp processes
+                app.logger.info(f"No 'formats' array, using top-level info for URL: {url}")
+                formats.append({
+                    'format_id': info.get('format_id', 'source'), # Use 'source' or 'direct' if no specific id
                     'ext': info.get('ext', 'unknown'),
-                    'resolution': info.get('resolution') or info.get('format_note', 'N/A'),
-                    'format_note': info.get('format_note', 'Direct Download'),
-                    'filesize': info.get('filesize'),
+                    'resolution': f"{info.get('width')}x{info.get('height')}" if info.get('width') and info.get('height') else info.get('resolution', 'N/A'),
+                    'format_note': info.get('format_note', 'Direct Source'),
+                    'filesize': info.get('filesize'), # Might be None
                     'filesize_approx': info.get('filesize_approx'),
+                    'fps': info.get('fps'),
                     'vcodec': info.get('vcodec', 'N/A'),
                     'acodec': info.get('acodec', 'N/A'),
+                    'tbr': info.get('tbr'),
+                    'abr': info.get('abr'),
+                    'vbr': info.get('vbr'),
+                    'url': info.get('url'),
+                    'manifest_url': info.get('manifest_url'),
+                    'protocol': info.get('protocol'),
+                    'language': info.get('language'),
                 })
 
-
             return jsonify({
-                'title': info.get('title', 'Video'),
-                'formats': formats
+                'title': info.get('title'),
+                'uploader': info.get('uploader'),
+                'duration': info.get('duration'),
+                'duration_string': info.get('duration_string'),
+                'thumbnail': info.get('thumbnail'),
+                'description': info.get('description'),
+                'webpage_url': info.get('webpage_url'),
+                'formats': formats,
+                'original_url': url # Echo back the requested URL for reference
             })
-    except Exception as e:
-        # Try to provide a more specific error if possible
-        error_message = str(e)
-        if "Unsupported URL" in error_message:
-            return jsonify({'error': f"Unsupported URL: {url}"}), 500
-        elif "Unable to extract video data" in error_message: # Common yt-dlp error
-            return jsonify({'error': f"Could not extract video data. The video might be private, unavailable, or the URL is incorrect."}), 500
-        return jsonify({'error': f"Error fetching video info: {error_message}"}), 500
+    except yt_dlp.utils.DownloadError as e_dl:
+        error_message_lower = str(e_dl).lower()
+        user_message = f"Failed to fetch video information: {str(e_dl)}" # Default detailed message
+
+        # More specific error messages based on content
+        if "unsupported url" in error_message_lower:
+            user_message = f"Unsupported URL: {url}. Please ensure it's a valid video page."
+        elif "this video is private" in error_message_lower:
+            user_message = "This video is private and cannot be accessed."
+        elif "video is unavailable" in error_message_lower:
+            user_message = "This video is unavailable."
+        elif "geo-restricted" in error_message_lower or "region-restricted" in error_message_lower:
+            user_message = "This video is geo-restricted and not available in your region."
+        elif "unable to extract video data" in error_message_lower: # Common yt-dlp error
+            user_message = "Could not extract video data. The video might be private, deleted, or the URL is incorrect."
+        
+        app.logger.error(f"DownloadError for URL {url}: {str(e_dl)}")
+        return jsonify({'error': user_message}), 500
+    except Exception as e_general:
+        app.logger.error(f"Unexpected error for URL {url}: {str(e_general)}")
+        return jsonify({'error': f"An unexpected error occurred while fetching video info."}), 500
 
 
 @app.route('/download_video', methods=['GET'])
 def download_video():
     url = request.args.get('url')
-    format_id = request.args.get('format_id')
+    format_id = request.args.get('format_id') # This is the specific format_id from the list
+    filename_on_server = None
 
-    if not url or not format_id:
-        return jsonify({'error': 'URL and Format ID are required'}), 400
+    # Get download options from query parameters
+    # Convert boolean strings to actual booleans, provide defaults
+    audio_only_str = request.args.get('audioOnly', 'false')
+    audio_only = audio_only_str.lower() == 'true'
+    
+    audio_format_pref = request.args.get('audioFormat', 'best')
+    video_quality_pref = request.args.get('videoQuality', 'best') # e.g., '720', 'best'
+    
+    embed_subs_str = request.args.get('embedSubs', 'false')
+    embed_subs = embed_subs_str.lower() == 'true'
+
+    if not url:
+        app.logger.warning("Download request failed: URL is required.")
+        return jsonify({'error': 'URL is required for download.'}), 400
+    if not format_id and not audio_only: # format_id is crucial unless it's audio_only where we can be more flexible
+        app.logger.warning(f"Download request for {url} failed: Format ID is required for video downloads.")
+        return jsonify({'error': 'Format ID is required for video downloads.'}), 400
+
+    app.logger.info(f"Download request for URL: {url}, Format ID: {format_id}, Options: audio_only={audio_only}, audio_format={audio_format_pref}, video_quality={video_quality_pref}, embed_subs={embed_subs}")
 
     try:
-        # Ensure the 'downloads' directory exists (it should, but double check)
         if not os.path.exists(DOWNLOADS_DIR):
             os.makedirs(DOWNLOADS_DIR)
 
+        # --- Construct ydl_opts based on user preferences ---
         ydl_opts = {
-            'format': format_id,
-            'outtmpl': os.path.join(DOWNLOADS_DIR, '%(title)s.%(ext)s'),
             'noplaylist': True,
-            # 'progress_hooks': [lambda d: print(d)] # for debugging
+            'overwrites': True, # Important for retries or if filename clashes (though we try to make them unique)
+            'quiet': True,
+            'no_warnings': True,
+            # Use a more unique filename template to avoid issues with concurrent downloads or special characters.
+            # %(id)s (video ID) and %(format_id)s are good for uniqueness.
+            'outtmpl': os.path.join(DOWNLOADS_DIR, '%(id)s_%(format_id)s.%(ext)s'),
         }
-        with YoutubeDL(ydl_opts) as ydl:
-            info = ydl.extract_info(url, download=True) # Trigger download
-            # The file is downloaded to the server's `downloads` directory.
-            # For a real-world app, you'd likely want to stream this back to the user
-            # or provide a direct link to the static file after download.
-            # For simplicity here, we'll just confirm download initiation on the server.
-            
-            # Attempt to find the downloaded file to provide its name
-            # This is a simplified way and might need refinement for robustness
-            filename = ydl.prepare_filename(info)
-            
-            # Check if the file exists (it should have been downloaded by yt-dlp)
-            if os.path.exists(filename):
-                 # This is a simplified approach. For large files, this will load the entire file into memory.
-                 # A more robust solution would use Flask's send_file with streaming.
-                def generate():
-                    with open(filename, 'rb') as f:
-                        while True:
-                            chunk = f.read(4096) # Read in chunks
-                            if not chunk:
-                                break
-                            yield chunk
-                    # Optionally, remove the file after streaming if it's a temporary download
-                    # os.remove(filename)
+        
+        postprocessors = []
 
-                # Ensure correct headers for download
-                # Extract the actual file name from the full path
-                base_filename = os.path.basename(filename)
-                return Response(generate(),
-                                mimetype=f"application/{info.get('ext', 'octet-stream')}",
-                                headers={"Content-Disposition": f"attachment;filename={base_filename}"})
+        if audio_only:
+            ydl_opts['extract_audio'] = True
+            # Let yt-dlp choose the best audio format if 'best' is specified by user
+            if audio_format_pref != 'best':
+                ydl_opts['audioformat'] = audio_format_pref
+                # Add postprocessor for specific audio format conversion if not 'best'
+                # This ensures the desired codec is used.
+                postprocessors.append({
+                    'key': 'FFmpegExtractAudio',
+                    'preferredcodec': audio_format_pref,
+                    'preferredquality': '0', # yt-dlp default, usually high quality for specified codec
+                })
+            # Format selection for audio_only:
+            # If 'best' audio format is chosen, 'bestaudio/best' lets yt-dlp pick the container.
+            # If a specific audio_format_pref is given, request it directly.
+            ydl_opts['format'] = 'bestaudio/best' if audio_format_pref == 'best' else f'bestaudio[ext={audio_format_pref}]/bestaudio'
 
+        else: # Video download (or video + audio)
+            # Start with the user-selected format_id if available, otherwise default to a flexible choice.
+            # The format_id from the client is generally a good specific choice.
+            selected_format = format_id if format_id else 'bestvideo+bestaudio/best'
+
+            if video_quality_pref != 'best':
+                try:
+                    quality_val = int(video_quality_pref)
+                    # Refine format: select best video up to specified height, plus best audio.
+                    # This string appends to the user's selected_format or yt-dlp's default.
+                    # It prefers formats that are already combined or allows merging.
+                    ydl_opts['format'] = f"{selected_format}[height<=?{quality_val}]/bestvideo[height<=?{quality_val}]+bestaudio/best[height<=?{quality_val}]"
+                except ValueError:
+                    app.logger.warning(f"Invalid video_quality_pref '{video_quality_pref}', defaulting to '{selected_format}'.")
+                    ydl_opts['format'] = selected_format # Fallback to selected_format if quality is not 'best' or numeric
             else:
-                return jsonify({'error': 'File not found after download completion.'}), 500
+                ydl_opts['format'] = selected_format # Use the format_id or default if quality is 'best'
+        
+        if embed_subs:
+            ydl_opts['writesubtitles'] = True
+            ydl_opts['subtitleslangs'] = ['en'] # Target English subtitles
+            ydl_opts['embedsubtitles'] = True   # Embed subtitles into the video file
+            # yt-dlp handles postprocessing for subtitle embedding if the output container supports it (e.g., mkv, mp4).
+            # Consider adding 'merge_output_format': 'mkv' if subtitle embedding often fails for mp4.
+
+        if postprocessors: # Add any accumulated postprocessors
+            ydl_opts['postprocessors'] = postprocessors
+        # --- End of ydl_opts construction ---
+
+        app.logger.debug(f"Attempting download with effective yt-dlp opts: {json.dumps(ydl_opts, indent=2)}")
+        
+        # Perform download
+        with YoutubeDL(ydl_opts) as ydl:
+            try:
+                info = ydl.extract_info(url, download=True)
+            except yt_dlp.utils.DownloadError as de_inner:
+                app.logger.error(f"yt-dlp DownloadError during download for {url}: {str(de_inner)}")
+                return jsonify({'error': f"Download failed: {str(de_inner)}"}), 500
+            except Exception as e_inner_extract:
+                app.logger.error(f"yt-dlp generic error during download for {url}: {str(e_inner_extract)}")
+                return jsonify({'error': f"An error occurred during video processing: {str(e_inner_extract)}"}), 500
+
+            filename_on_server = ydl.prepare_filename(info)
+            
+            # Determine suggested filename for client (more robustly)
+            title = info.get('title', 'video')
+            # Extension should be from 'info' after download and potential postprocessing
+            downloaded_ext = info.get('ext', 'unknown') 
+            if audio_only and audio_format_pref != 'best':
+                # If a specific audio format was requested, use that for the extension,
+                # as postprocessing should have converted it.
+                downloaded_ext = audio_format_pref
+            
+            suggested_filename = f"{title}.{downloaded_ext}"
+
+            if not filename_on_server or not os.path.exists(filename_on_server):
+                app.logger.error(f"File not found on server after download attempt: {filename_on_server} for URL {url}")
+                return jsonify({'error': 'File not found on server after download processing.'}), 500
+            
+            # Determine mimetype based on actual downloaded extension
+            mimetype = f"audio/{downloaded_ext}" if audio_only else f"video/{downloaded_ext}"
+            if downloaded_ext in ['mp3', 'm4a', 'opus', 'wav', 'mp4', 'mkv', 'webm']:
+                 mimetype = f"{'audio' if audio_only else 'video'}/{downloaded_ext}"
+            else: # Generic fallback
+                mimetype = 'application/octet-stream'
 
 
-    except Exception as e:
-        return jsonify({'error': f"Error downloading video: {str(e)}"}), 500
+            app.logger.info(f"Streaming file {filename_on_server} as {suggested_filename} with mimetype {mimetype}")
+            return send_from_directory(
+                directory=os.path.dirname(filename_on_server),
+                path=os.path.basename(filename_on_server),
+                as_attachment=True,
+                download_name=suggested_filename,
+                mimetype=mimetype
+            )
+
+    except yt_dlp.utils.DownloadError as e_outer_dl: # Errors before or during ydl context
+        app.logger.error(f"Outer DownloadError for {url}: {str(e_outer_dl)}")
+        return jsonify({'error': f"A download error occurred: {str(e_outer_dl)}"}), 500
+    except Exception as e_general_outer:
+        app.logger.error(f"Outer general error for {url}: {str(e_general_outer)}")
+        return jsonify({'error': f"An unexpected server error occurred during download preparation."}), 500
+    finally:
+        if filename_on_server and os.path.exists(filename_on_server):
+            try:
+                os.remove(filename_on_server)
+                app.logger.info(f"Successfully deleted temporary file: {filename_on_server}")
+            except OSError as e_remove:
+                app.logger.error(f"Error deleting temporary file {filename_on_server}: {str(e_remove)}")
 
 if __name__ == '__main__':
     # Before running the app, ensure Flask is installed.
@@ -144,4 +288,17 @@ if __name__ == '__main__':
     print("Flask and yt-dlp are required. Install them with: pip install Flask yt-dlp")
     print(f"Serving on http://127.0.0.1:5000")
     print(f"Video downloads will be saved to: {DOWNLOADS_DIR}")
+    # Set up basic logging for the app
+    if not app.debug:
+        import logging
+        from logging.handlers import RotatingFileHandler
+        file_handler = RotatingFileHandler('web_server.log', maxBytes=10240, backupCount=10)
+        file_handler.setFormatter(logging.Formatter(
+            '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
+        ))
+        file_handler.setLevel(logging.INFO)
+        app.logger.addHandler(file_handler)
+        app.logger.setLevel(logging.INFO)
+        app.logger.info('yt-dlp Web UI startup')
+
     app.run(host='0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
This commit introduces a functional web UI for yt-dlp, allowing you to:
- Fetch video information and available formats.
- Download videos or audio by selecting formats.
- Configure download options: audio-only, audio format, video quality, and subtitle embedding.

Key changes include:
- Backend (Flask): Serves the UI, extracts video info using yt-dlp, and handles download requests with user-specified options. Downloads are streamed to the client and then deleted from the server.
- Frontend (HTML, CSS, JS): Provides an interface for URL input, option selection, format display, and download initiation. Includes loading indicators and error feedback.
- README.md: Added comprehensive documentation for setup, usage, and features.
- Code Quality: Refactored and cleaned up the codebase for better readability, maintainability, and basic accessibility.