### PR TITLE
docs: Correct uv pip sync command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ This web UI is a wrapper around the versatile `yt-dlp` tool. All video fetching 
     Choose **one** of the above methods to create and activate your virtual environment. The `uv` method is preferred for consistency with the project's dependency management.
 
 3.  **Install dependencies**:
-    With your virtual environment activated, install the dependencies using `uv`. This command installs the exact versions specified in `uv.lock`, ensuring a reproducible environment.
+    Dependencies are defined in `pyproject.toml` and locked in `uv.lock`.
+    With your virtual environment activated, install them using `uv`:
     ```bash
-    uv pip sync
+    uv pip sync --locked pyproject.toml
     ```
+    This command installs the exact versions specified in `uv.lock`, ensuring a reproducible environment by synchronizing your environment with the `pyproject.toml` file using the locked dependencies.
 
 ## Running the Application
 


### PR DESCRIPTION
Updated the README.md to use `uv pip sync --locked pyproject.toml` for dependency installation, as this correctly utilizes the lock file in conjunction with the pyproject.toml specification.