### PR TITLE
fix: Ensure all dependencies are installed with uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ This web UI is a wrapper around the versatile `yt-dlp` tool. All video fetching 
 
 ### Project Files for Dependency Management
 
--   **`pyproject.toml`**: This file defines the project metadata and its direct dependencies (e.g., Flask, yt-dlp).
--   **`uv.lock`**: This is an auto-generated lock file that pins the exact versions of all dependencies (direct and indirect) to ensure consistent and reproducible environments. It should be committed to the repository.
+-   **`pyproject.toml`**: Lists the project's direct, high-level dependencies.
+-   **`uv.lock`**: An auto-generated lock file that captures the full, resolved dependency tree from `pyproject.toml`, ensuring version consistency.
+-   **`requirements.txt`**: An auto-generated file derived from `uv.lock` that explicitly lists all direct and transitive dependencies. This file is used by `uv pip sync requirements.txt` for reliable environment setup.
 
 ### Installation Steps
 
@@ -64,12 +65,12 @@ This web UI is a wrapper around the versatile `yt-dlp` tool. All video fetching 
     Choose **one** of the above methods to create and activate your virtual environment. The `uv` method is preferred for consistency with the project's dependency management.
 
 3.  **Install dependencies**:
-    Dependencies are defined in `pyproject.toml` and locked in `uv.lock`.
+    The full list of dependencies, including all sub-dependencies, is provided in `requirements.txt`. This file is generated from `uv.lock` to ensure consistent, reproducible environments.
     With your virtual environment activated, install them using `uv`:
     ```bash
-    uv pip sync pyproject.toml
+    uv pip sync requirements.txt
     ```
-    This command installs the exact versions specified in `uv.lock` by synchronizing your environment with the `pyproject.toml` file, automatically using the associated lock file.
+    This command installs the exact versions specified in `requirements.txt`.
 
 ## Running the Application
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+asgiref==3.8.1
+blinker==1.9.0
+click==8.2.1
+flask==3.1.1
+itsdangerous==2.2.0
+jinja2==3.1.6
+markupsafe==3.0.2
+python-dotenv==1.1.0
+typing-extensions==4.13.2
+werkzeug==3.1.3
+yt-dlp==2025.5.22

--- a/web_server.log
+++ b/web_server.log
@@ -1,0 +1,2 @@
+2025-05-23 01:08:21,164 INFO: yt-dlp Web UI startup [in /app/web_server.py:302]
+2025-05-23 01:08:21,997 INFO: yt-dlp Web UI startup [in /app/web_server.py:302]


### PR DESCRIPTION
Resolved `ModuleNotFoundError: No module named 'werkzeug'` by:
1. Ensuring `uv lock` captures all transitive dependencies for Flask, including Werkzeug.
2. Generating a `requirements.txt` from the complete `uv.lock`.
3. Updating `README.md` to use `uv pip sync requirements.txt` for dependency installation, which reliably installs all necessary packages.

This ensures a reproducible and correct environment setup using `uv`.